### PR TITLE
Set reset_password_sent_at to current time when emailing reset password ...

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,6 +5,9 @@ class UserMailer < ActionMailer::Base
   def reactivate_user(user)
     @user = user
     mail(:to => @user.email, :subject => "Good for Nothing Account Reactivation")
+    # Set password token sent at time for devise.
+    user.reset_password_sent_at = Time.now
+    user.save
   end
   
 end


### PR DESCRIPTION
...token Fixes #107

See http://stackoverflow.com/questions/6853026/rails-devise-reset-password-token-keeps-getting-marked-as-expired for reasoning.
When overriding the devise send_password_reset_email function you need to set the time at which the token was sent.
