### PR TITLE
Fixed layout of community numbers on firefox

### DIFF
--- a/app/assets/stylesheets/views/home.css.erb
+++ b/app/assets/stylesheets/views/home.css.erb
@@ -97,6 +97,10 @@
 	margin: 0;
 }
 
+.section_home #community_infographic {
+	list-style-position: outside;
+}
+
 .section_home #community_infographic:last-child {
 	margin-bottom: 36px;
 }


### PR DESCRIPTION
Numbers for Good For Nothingers were falling over onto two lines when viewed in firefox.
